### PR TITLE
Fix: Use Storage::path() for backup restores

### DIFF
--- a/app/Http/Controllers/SystemBackupController.php
+++ b/app/Http/Controllers/SystemBackupController.php
@@ -70,7 +70,7 @@ class SystemBackupController extends Controller
         try {
             if ($request->hasFile('backup_file')) {
                 $path = $request->file('backup_file')->storeAs('temp_restores', 'restore_' . time() . '.json');
-                $fullPath = storage_path('app/' . $path);
+                $fullPath = Storage::path($path);
                 $this->backupService->restoreFromPath($fullPath, $request->password);
                 unlink($fullPath);
             } else {


### PR DESCRIPTION
Fixed the "Backup file not found" error. The issue was caused by a mismatch between how the file was stored (relative to storage/app/private) and how the system tried to read it (assuming storage/app).

Fix Deployed:

Updated SystemBackupController to use Storage::path() which correctly resolves the full absolute path of the uploaded backup file, regardless of the underlying disk configuration.