### PR TITLE
feat: Cloudflare DNS-01 SSL challenge support

### DIFF
--- a/app/Http/Controllers/SystemSslController.php
+++ b/app/Http/Controllers/SystemSslController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Controllers\Controller;
 use App\Services\SslManagerService;
 use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Log;
 
 use App\Models\SystemSetting;
@@ -14,13 +15,61 @@ class SystemSslController extends Controller
     public function store(Request $request, SslManagerService $sslManager)
     {
         $request->validate([
-            'domain' => 'required|string|regex:/^(?!:\/\/)(?=.{1,255}$)((.{1,63}\.){1,127}(?![0-9]*$)[a-z0-9-]+\.?)$/i',
-            'email' => 'required|email',
+            'domain'           => 'required|string|regex:/^(?!:\/\/)(?=.{1,255}$)((.{1,63}\.){1,127}(?![0-9]*$)[a-z0-9-]+\.?)$/i',
+            'email'            => 'required|email',
+            'challenge_method' => 'required|in:http,cloudflare',
+            'cf_token'         => 'nullable|string',
+            'cf_zone_id'       => ['nullable', 'string', 'regex:/^[a-f0-9]{32}$/'],
         ]);
 
         try {
-            $domain = $request->input('domain');
-            $result = $sslManager->install($domain, $request->input('email'));
+            $domain        = $request->input('domain');
+            $method        = $request->input('challenge_method', 'http');
+            $cfToken       = null;
+
+            // Persist challenge method choice regardless of outcome
+            SystemSetting::updateOrCreate(
+                ['key' => 'ssl_challenge_method'],
+                ['value' => $method]
+            );
+
+            if ($method === 'cloudflare') {
+                // Validate CF-specific fields
+                if ($request->filled('cf_zone_id')) {
+                    SystemSetting::updateOrCreate(
+                        ['key' => 'cf_zone_id'],
+                        ['value' => $request->input('cf_zone_id')]
+                    );
+                }
+
+                if ($request->filled('cf_token')) {
+                    // Encrypt token before storing — never stored in plaintext
+                    SystemSetting::updateOrCreate(
+                        ['key' => 'cf_api_token'],
+                        ['value' => encrypt($request->input('cf_token'))]
+                    );
+                }
+
+                // Resolve token from DB (use newly saved or previously saved)
+                $encryptedToken = SystemSetting::where('key', 'cf_api_token')->value('value');
+                if (!$encryptedToken) {
+                    return response()->json([
+                        'success' => false,
+                        'message' => 'A Cloudflare API token is required. Please enter your token.',
+                    ], 422);
+                }
+
+                try {
+                    $cfToken = decrypt($encryptedToken);
+                } catch (\Exception $e) {
+                    return response()->json([
+                        'success' => false,
+                        'message' => 'Stored Cloudflare token is invalid or the app key has changed. Please re-enter your token.',
+                    ], 422);
+                }
+            }
+
+            $result = $sslManager->install($domain, $request->input('email'), $method, $cfToken);
 
             if ($result['success']) {
                 // Update database settings to reflect the change in UI
@@ -28,8 +77,8 @@ class SystemSslController extends Controller
                 SystemSetting::updateOrCreate(['key' => 'site_protocol'], ['value' => 'https']);
 
                 return response()->json([
-                    'success' => true,
-                    'message' => 'SSL Certificate installed successfully. Reloading...',
+                    'success'  => true,
+                    'message'  => 'SSL Certificate installed successfully. Reloading...',
                     'redirect' => 'https://' . $domain . '/system/settings',
                 ]);
             }
@@ -76,5 +125,19 @@ class SystemSslController extends Controller
                 'message' => 'An unexpected error occurred: ' . $e->getMessage(),
             ], 500);
         }
+    }
+
+    /**
+     * Returns non-sensitive SSL/Cloudflare status for the settings modal.
+     * The API token is NEVER included — only a boolean indicating it exists.
+     */
+    public function status(): JsonResponse
+    {
+        return response()->json([
+            'challenge_method'    => SystemSetting::where('key', 'ssl_challenge_method')->value('value') ?? 'http',
+            'cf_token_configured' => SystemSetting::where('key', 'cf_api_token')->exists(),
+            'cf_zone_id'          => SystemSetting::where('key', 'cf_zone_id')->value('value') ?? '',
+            'ssl_active'          => (SystemSetting::where('key', 'site_protocol')->value('value') === 'https'),
+        ]);
     }
 }

--- a/app/Services/SslManagerService.php
+++ b/app/Services/SslManagerService.php
@@ -20,7 +20,7 @@ class SslManagerService
     /**
      * Install SSL certificate for the given domain
      */
-    public function install(string $domain, string $email): array
+    public function install(string $domain, string $email, string $method = 'http', ?string $cfToken = null): array
     {
         // Strict domain validation to prevent Nginx config injection
         if (!preg_match('/^(?!:\/\/)(?=.{1,255}$)((.{1,63}\.){1,127}(?![0-9]*$)[a-z0-9-]+\.?)$/i', $domain) || preg_match('/[;{}\n\r]/', $domain)) {
@@ -29,7 +29,14 @@ class SslManagerService
 
         try {
             // 1. Request Certificate
-            $this->requestCertificate($domain, $email);
+            if ($method === 'cloudflare') {
+                if (!$cfToken) {
+                    throw new \Exception('A Cloudflare API token is required for DNS-01 verification.');
+                }
+                $this->requestCertificateViaCloudflareDns($domain, $email, $cfToken);
+            } else {
+                $this->requestCertificate($domain, $email);
+            }
 
             // 2. Safely Apply Nginx Configuration
             // We use a separate try-catch to rollback if applying config fails
@@ -80,7 +87,8 @@ class SslManagerService
         // Run certbot safely
         // --webroot using public dir as root for challenges
         $cmd = "sudo certbot certonly --webroot -w " . escapeshellarg(public_path()) .
-            " -d " . escapeshellarg($domain) . " --non-interactive --agree-tos -m " . escapeshellarg($email) . " --deploy-hook ''";
+            " -d " . escapeshellarg($domain) . " --non-interactive --agree-tos -m " . escapeshellarg($email) .
+            " --deploy-hook 'sudo systemctl reload nginx'";
 
         $result = Process::run($cmd);
 
@@ -90,6 +98,47 @@ class SslManagerService
 
         // Verify certificates exist (skipped due to permissions - nginx -t will verify later)
         // Note: www-data cannot read /etc/letsencrypt/live directly, causing false negatives.
+    }
+
+    protected function requestCertificateViaCloudflareDns(string $domain, string $email, string $cfToken): void
+    {
+        // Check if certbot exists
+        $check = Process::run('which certbot');
+        if ($check->failed()) {
+            throw new \Exception('Certbot is not installed. Please run the installer script.');
+        }
+
+        // Check if the dns-cloudflare plugin Python package is importable (no sudo needed)
+        $pluginCheck = Process::run('python3 -c "import certbot_dns_cloudflare"');
+        if ($pluginCheck->failed()) {
+            throw new \Exception(
+                'The certbot-dns-cloudflare plugin is not installed. ' .
+                'Please run: sudo apt install python3-certbot-dns-cloudflare (or equivalent for your OS).'
+            );
+        }
+
+        // Write temp credentials file — chmod 600 immediately, deleted in finally block
+        $credPath = storage_path('app/cf-credentials-' . uniqid() . '.ini');
+        file_put_contents($credPath, "dns_cloudflare_api_token = {$cfToken}\n");
+        chmod($credPath, 0600);
+
+        try {
+            $cmd = "sudo certbot certonly --dns-cloudflare" .
+                " --dns-cloudflare-credentials " . escapeshellarg($credPath) .
+                " -d " . escapeshellarg($domain) .
+                " --non-interactive --agree-tos -m " . escapeshellarg($email);
+
+            $result = Process::run($cmd);
+
+            if ($result->failed()) {
+                throw new \Exception("Certbot (DNS-01) failed: " . $result->errorOutput());
+            }
+        } finally {
+            // Always remove the credentials file — even on failure
+            if (file_exists($credPath)) {
+                unlink($credPath);
+            }
+        }
     }
 
     public function deleteCertificate(string $domain): void

--- a/install_admixcentral.sh
+++ b/install_admixcentral.sh
@@ -723,16 +723,16 @@ main() {
 
   log "Installing Nginx + Database Server + Supervisor + Redis"
   if [[ "$OS_FAMILY" == "debian" ]]; then
-    pkg_install nginx mysql-server supervisor certbot python3-certbot-nginx redis-server
+    pkg_install nginx mysql-server supervisor certbot python3-certbot-nginx python3-certbot-dns-cloudflare redis-server
   elif [[ "$OS_FAMILY" == "redhat" ]]; then
-    pkg_install nginx mariadb-server supervisor certbot python3-certbot-nginx redis
+    pkg_install nginx mariadb-server supervisor certbot python3-certbot-nginx python3-certbot-dns-cloudflare redis
   elif [[ "$OS_FAMILY" == "arch" ]]; then
-    pkg_install nginx mariadb supervisor certbot certbot-nginx redis
+    pkg_install nginx mariadb supervisor certbot certbot-nginx certbot-dns-cloudflare redis
     if [[ ! -d "/var/lib/mysql/mysql" ]]; then
       mariadb-install-db --user=mysql --basedir=/usr --datadir=/var/lib/mysql || true
     fi
   elif [[ "$OS_FAMILY" == "suse" ]]; then
-    pkg_install nginx mariadb supervisor certbot python3-certbot-nginx redis
+    pkg_install nginx mariadb supervisor certbot python3-certbot-nginx python3-certbot-dns-cloudflare redis
   fi
 
   log "Enabling and starting Redis"
@@ -865,9 +865,13 @@ main() {
   "
 
   log "Configuring sudoers for SSL management, Certbot, and Performance Tuning"
+  # Resolve actual certbot binary (may differ between /usr/bin and /snap/bin)
+  local certbot_bin
+  certbot_bin="$(command -v certbot || echo /usr/bin/certbot)"
+
   cat >/etc/sudoers.d/admixcentral <<EOF
 # SSL / Nginx
-${RUNTIME_WEB_USER} ALL=(ALL) NOPASSWD: /usr/bin/certbot, /usr/sbin/nginx, /usr/bin/systemctl reload nginx, /usr/bin/tee /etc/nginx/sites-available/admixcentral, /usr/bin/tee /etc/nginx/conf.d/admixcentral.conf
+${RUNTIME_WEB_USER} ALL=(ALL) NOPASSWD: /usr/bin/certbot, ${certbot_bin}, /usr/sbin/nginx, /usr/bin/systemctl reload nginx, /usr/bin/tee /etc/nginx/sites-available/admixcentral, /usr/bin/tee /etc/nginx/conf.d/admixcentral.conf
 # Performance Tuning — supervisor config writes
 ${RUNTIME_WEB_USER} ALL=(ALL) NOPASSWD: /usr/bin/cp /tmp/admix_tune_* /etc/supervisor/conf.d/admix-worker.conf
 ${RUNTIME_WEB_USER} ALL=(ALL) NOPASSWD: /usr/bin/cp /tmp/admix_tune_* /etc/supervisor/conf.d/admix-worker.ini
@@ -887,6 +891,16 @@ ${RUNTIME_WEB_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart php8.1-fpm
 ${RUNTIME_WEB_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart php-fpm
 ${RUNTIME_WEB_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart php8-fpm
 EOF
+
+  # If RUNTIME_WEB_USER is not www-data, also add www-data explicitly —
+  # PHP-FPM pool often runs as www-data regardless of the detected install user.
+  if [[ "${RUNTIME_WEB_USER}" != "www-data" ]] && id www-data >/dev/null 2>&1; then
+    cat >>/etc/sudoers.d/admixcentral <<EOF
+# SSL / Nginx (www-data — PHP-FPM pool user)
+www-data ALL=(ALL) NOPASSWD: /usr/bin/certbot, ${certbot_bin}, /usr/sbin/nginx, /usr/bin/systemctl reload nginx, /usr/bin/tee /etc/nginx/sites-available/admixcentral, /usr/bin/tee /etc/nginx/conf.d/admixcentral.conf
+EOF
+  fi
+
   chmod 0440 /etc/sudoers.d/admixcentral || true
 
   configure_nginx_site

--- a/resources/views/system/customization/index.blade.php
+++ b/resources/views/system/customization/index.blade.php
@@ -1046,12 +1046,17 @@
                                                         clip-rule="evenodd" />
                                                 </svg>
                                             </div>
-                                            <div class="ml-3 flex-1 md:flex md:justify-between">
+                                            <div class="ml-3 flex-1 md:flex md:justify-between md:items-center">
                                                 <p class="text-sm text-green-700 dark:text-green-300">
                                                     <span class="font-medium">Secure Connection.</span>
                                                     SSL is installed and active.
                                                 </p>
-                                                <p class="mt-3 text-sm md:ml-6 md:mt-0">
+                                                <p class="mt-3 text-sm md:ml-6 md:mt-0 flex items-center gap-4">
+                                                    <button type="button"
+                                                        @click="openModal('{{ $settings['site_url'] ?? '' }}')"
+                                                        class="whitespace-nowrap font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 hover:underline">
+                                                        Reconfigure
+                                                    </button>
                                                     <button type="button" @click="confirmUninstall()"
                                                         class="whitespace-nowrap font-medium text-red-600 dark:text-red-400 hover:text-red-500 hover:underline">
                                                         Uninstall SSL
@@ -1065,43 +1070,114 @@
                         </div>
 
                         <!-- SSL Modal -->
-                        <x-modal name="install-ssl-modal" :show="$errors->isNotEmpty()" focusable maxWidth="md">
+                        <x-modal name="install-ssl-modal" :show="$errors->isNotEmpty()" focusable maxWidth="lg">
                             <div class="p-6">
-                                <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white mb-4">Install
-                                    Let's Encrypt SSL</h3>
+                                <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white mb-1">Install Let's Encrypt SSL</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mb-5">Certificate is issued free via Let's Encrypt. Choose how your domain ownership is verified.</p>
 
-                                <div class="space-y-4">
+                                <div class="space-y-5">
+                                    <!-- Domain -->
                                     <div>
-                                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Domain
-                                            Name</label>
+                                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Domain Name</label>
                                         <input type="text" x-model="domain"
-                                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                                            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                                             placeholder="central.example.com">
                                     </div>
+
+                                    <!-- Email -->
                                     <div>
-                                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Email
-                                            Address (for renewal)</label>
+                                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Email Address <span class="font-normal text-gray-400">(for renewal notices)</span></label>
                                         <input type="email" x-model="email"
-                                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                                            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                                             placeholder="admin@example.com">
                                     </div>
 
+                                    <!-- Verification Method -->
+                                    <div>
+                                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Verification Method</label>
+                                        <div class="grid grid-cols-2 gap-3">
+                                            <!-- HTTP option -->
+                                            <label class="relative cursor-pointer">
+                                                <input type="radio" x-model="challengeMethod" value="http" class="peer sr-only">
+                                                <div class="flex flex-col gap-1 p-3 rounded-lg border-2 border-gray-200 dark:border-gray-600 hover:border-indigo-300 dark:hover:border-indigo-500 peer-checked:border-indigo-600 peer-checked:bg-indigo-50 dark:peer-checked:bg-indigo-900/30 transition-all cursor-pointer">
+                                                    <div class="flex items-center gap-2">
+                                                        <svg class="w-4 h-4 text-indigo-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" /></svg>
+                                                        <span class="text-sm font-medium text-gray-900 dark:text-white">HTTP Verification</span>
+                                                    </div>
+                                                    <p class="text-xs text-gray-500 dark:text-gray-400 pl-6">Port 80 must be open and reachable</p>
+                                                </div>
+                                            </label>
+                                            <!-- Cloudflare DNS option -->
+                                            <label class="relative cursor-pointer">
+                                                <input type="radio" x-model="challengeMethod" value="cloudflare" class="peer sr-only">
+                                                <div class="flex flex-col gap-1 p-3 rounded-lg border-2 border-gray-200 dark:border-gray-600 hover:border-orange-300 dark:hover:border-orange-500 peer-checked:border-orange-500 peer-checked:bg-orange-50 dark:peer-checked:bg-orange-900/20 transition-all cursor-pointer">
+                                                    <div class="flex items-center gap-2">
+                                                        <svg class="w-4 h-4 text-orange-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" /></svg>
+                                                        <span class="text-sm font-medium text-gray-900 dark:text-white">Cloudflare DNS</span>
+                                                    </div>
+                                                    <p class="text-xs text-gray-500 dark:text-gray-400 pl-6">No port 80 needed &mdash; works with proxied domains</p>
+                                                </div>
+                                            </label>
+                                        </div>
+
+                                        <!-- Re-issue warning (shown when SSL is active and method changes) -->
+                                        <div x-show="sslActive && statusLoaded && challengeMethod !== savedChallengeMethod"
+                                            class="mt-2 flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700/50 rounded-md p-2.5">
+                                            <svg class="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+                                            <span>Changing the verification method will <strong>re-issue your certificate</strong>. There will be a brief reload during the switchover.</span>
+                                        </div>
+                                    </div>
+
+                                    <!-- Cloudflare Fields -->
+                                    <div x-show="challengeMethod === 'cloudflare'" class="space-y-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                                        <!-- API Token -->
+                                        <div>
+                                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                                Cloudflare API Token
+                                                <span class="ml-1 text-xs font-normal text-gray-400">(write-only)</span>
+                                            </label>
+                                            <input type="password" x-model="cfToken" autocomplete="new-password"
+                                                class="block w-full rounded-md border-gray-300 shadow-sm focus:border-orange-500 focus:ring-orange-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white font-mono"
+                                                placeholder="Enter API token">
+                                            <!-- Token configured hint -->
+                                            <p x-show="cfTokenConfigured && !cfToken"
+                                                class="mt-1.5 text-xs text-emerald-600 dark:text-emerald-400 flex items-center gap-1">
+                                                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" /></svg>
+                                                Token already configured &mdash; leave blank to keep, or type a new value to replace
+                                            </p>
+                                            <p x-show="!cfTokenConfigured"
+                                                class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                                                Requires <strong>Zone &rarr; DNS &rarr; Edit</strong> permission. Token is encrypted before storage and never retrievable.
+                                            </p>
+                                        </div>
+
+                                        <!-- Zone ID -->
+                                        <div>
+                                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Zone ID</label>
+                                            <input type="text" x-model="cfZoneId"
+                                                class="block w-full rounded-md border-gray-300 shadow-sm focus:border-orange-500 focus:ring-orange-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white font-mono"
+                                                placeholder="e.g. a1b2c3d4e5f6...  (32 hex chars)">
+                                            <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                                                Found in Cloudflare Dashboard &rarr; your domain &rarr; Overview &rarr; API section.
+                                            </p>
+                                        </div>
+                                    </div>
+
                                     <!-- Error Message -->
-                                    <div x-show="error" class="text-red-500 text-sm mt-2" x-text="error"></div>
+                                    <div x-show="error" class="flex items-start gap-2 text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/50 rounded-md p-3">
+                                        <svg class="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                                        <span x-text="error"></span>
+                                    </div>
                                 </div>
 
                                 <div class="mt-6 flex justify-end gap-3">
                                     <button type="button" x-on:click="$dispatch('close')"
-                                        class="rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">Cancel</button>
+                                        class="rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-gray-900 dark:text-white shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600">Cancel</button>
                                     <button type="button" @click="installSsl" :disabled="loading"
                                         class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50 flex items-center gap-2">
-                                        <svg x-show="loading" class="animate-spin h-4 w-4 text-white" fill="none"
-                                            viewBox="0 0 24 24">
-                                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor"
-                                                stroke-width="4"></circle>
-                                            <path class="opacity-75" fill="currentColor"
-                                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z">
-                                            </path>
+                                        <svg x-show="loading" class="animate-spin h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                                         </svg>
                                         <span x-text="loading ? 'Installing...' : 'Install Certificate'"></span>
                                     </button>
@@ -1286,30 +1362,86 @@
                                 showModal: false,
                                 domain: '',
                                 email: '',
+                                // Challenge method state
+                                challengeMethod: 'http',
+                                savedChallengeMethod: 'http', // from DB — used to detect change
+                                cfToken: '',                   // never pre-filled — write-only
+                                cfZoneId: '',
+                                cfTokenConfigured: false,
+                                sslActive: false,
+                                statusLoaded: false,
                                 loading: false,
                                 error: null,
-                                openModal(currentUrl) {
+
+                                async openModal(currentUrl) {
                                     this.domain = currentUrl.replace(/^https?:\/\//, '').replace(/\/$/, '');
                                     this.error = null;
+                                    this.cfToken = '';           // always blank on open — write-only
+                                    this.statusLoaded = false;
+
+                                    // Fetch non-sensitive SSL status to hydrate modal fields
+                                    try {
+                                        const res = await fetch('{{ route("system.ssl.status") }}', {
+                                            headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                                        });
+                                        const s = await res.json();
+                                        this.challengeMethod      = s.challenge_method   || 'http';
+                                        this.savedChallengeMethod = s.challenge_method   || 'http';
+                                        this.cfTokenConfigured    = !!s.cf_token_configured;
+                                        this.cfZoneId             = s.cf_zone_id         || '';
+                                        this.sslActive            = !!s.ssl_active;
+                                    } catch (_) {
+                                        // Non-fatal — defaults remain
+                                    }
+
+                                    this.statusLoaded = true;
                                     window.dispatchEvent(new CustomEvent('open-modal', { detail: 'install-ssl-modal' }));
                                 },
+
                                 async installSsl() {
                                     if (!this.domain || !this.email) {
                                         this.error = 'Please fill in all fields.';
                                         return;
                                     }
 
+                                    // Cloudflare-specific validation
+                                    if (this.challengeMethod === 'cloudflare') {
+                                        if (!this.cfZoneId || !/^[a-f0-9]{32}$/.test(this.cfZoneId.trim())) {
+                                            this.error = 'Please enter a valid Cloudflare Zone ID (32-character hex string).';
+                                            return;
+                                        }
+                                        if (!this.cfToken && !this.cfTokenConfigured) {
+                                            this.error = 'A Cloudflare API Token is required.';
+                                            return;
+                                        }
+                                    }
+
                                     this.loading = true;
                                     this.error = null;
 
                                     try {
+                                        // Build payload — only include CF fields when needed
+                                        const body = {
+                                            domain: this.domain,
+                                            email: this.email,
+                                            challenge_method: this.challengeMethod,
+                                        };
+
+                                        if (this.challengeMethod === 'cloudflare') {
+                                            body.cf_zone_id = this.cfZoneId.trim();
+                                            // Only send token if user entered a new one
+                                            if (this.cfToken) {
+                                                body.cf_token = this.cfToken;
+                                            }
+                                        }
+
                                         const response = await fetch('{{ route("system.ssl.install") }}', {
                                             method: 'POST',
                                             headers: {
                                                 'Content-Type': 'application/json',
                                                 'X-CSRF-TOKEN': '{{ csrf_token() }}'
                                             },
-                                            body: JSON.stringify({ domain: this.domain, email: this.email })
+                                            body: JSON.stringify(body)
                                         });
 
                                         const data = await response.json();

--- a/routes/web.php
+++ b/routes/web.php
@@ -360,6 +360,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->middleware([App\Http\Middleware\CheckRole::class . ':global_admin'])
         ->name('system.ssl.uninstall');
 
+    Route::get('/system/ssl/status', [App\Http\Controllers\SystemSslController::class, 'status'])
+        ->middleware([App\Http\Middleware\CheckRole::class . ':global_admin'])
+        ->name('system.ssl.status');
+
     // Global System Backups
     Route::get('/system/backups', [App\Http\Controllers\SystemBackupController::class, 'index'])
         ->middleware([App\Http\Middleware\CheckRole::class . ':global_admin'])

--- a/upgrade_admixcentral.sh
+++ b/upgrade_admixcentral.sh
@@ -125,26 +125,35 @@ main() {
 
   log "AdmixCentral found at $INSTALL_DIR"
 
-  # ── 1. Install Redis + PHP extension ──────────────────────────────────────
-  log "Step 1/6 — Installing Redis and PHP Redis extension"
+  # ── 1. Install Redis + PHP extension + Certbot DNS plugin ─────────────────
+  log "Step 1/6 — Installing Redis, PHP Redis extension, and Certbot DNS-Cloudflare plugin"
 
   case "$OS_FAMILY" in
     debian)
       apt-get update -y -q
       pkg_install redis-server "php${PHP_VER}-redis"
       systemctl enable --now redis-server || true
+      # Certbot DNS-01 Cloudflare plugin (idempotent — no-op if already installed)
+      pkg_install python3-certbot-dns-cloudflare || \
+        info "Warning: python3-certbot-dns-cloudflare not available via apt — Cloudflare DNS SSL will not work on this server"
       ;;
     redhat)
       pkg_install redis php-redis
       systemctl enable --now redis || true
+      pkg_install python3-certbot-dns-cloudflare || \
+        info "Warning: python3-certbot-dns-cloudflare not available — install manually for Cloudflare DNS SSL"
       ;;
     arch)
       pkg_install redis php-redis
       systemctl enable --now redis || true
+      pkg_install certbot-dns-cloudflare || \
+        info "Warning: certbot-dns-cloudflare not available — install manually for Cloudflare DNS SSL"
       ;;
     suse)
       pkg_install redis php8-redis
       systemctl enable --now redis || true
+      pkg_install python3-certbot-dns-cloudflare || \
+        info "Warning: python3-certbot-dns-cloudflare not available — install manually for Cloudflare DNS SSL"
       ;;
   esac
 
@@ -269,9 +278,18 @@ main() {
   local web_user
   web_user="$(stat -c '%U' "${INSTALL_DIR}/artisan" 2>/dev/null || echo "www-data")"
 
+  # Resolve the actual certbot binary (may be /snap/bin/certbot on Ubuntu 22+)
+  local certbot_bin
+  certbot_bin="$(command -v certbot 2>/dev/null || echo /usr/bin/certbot)"
+
+  # Detect the PHP-FPM pool runtime user (may differ from the artisan file owner)
+  local fpm_user
+  fpm_user="$(ps aux 2>/dev/null | awk '/php-fpm.*pool www/ && !/root/{print $1; exit}')"
+  fpm_user="${fpm_user:-www-data}"
+
   cat >/etc/sudoers.d/admixcentral <<EOF
 # SSL / Nginx
-${web_user} ALL=(ALL) NOPASSWD: /usr/bin/certbot, /usr/sbin/nginx, /usr/bin/systemctl reload nginx, /usr/bin/tee /etc/nginx/sites-available/admixcentral, /usr/bin/tee /etc/nginx/conf.d/admixcentral.conf
+${web_user} ALL=(ALL) NOPASSWD: /usr/bin/certbot, ${certbot_bin}, /usr/sbin/nginx, /usr/bin/systemctl reload nginx, /usr/bin/tee /etc/nginx/sites-available/admixcentral, /usr/bin/tee /etc/nginx/conf.d/admixcentral.conf
 # Performance Tuning — supervisor config writes
 ${web_user} ALL=(ALL) NOPASSWD: /usr/bin/cp /tmp/admix_tune_* /etc/supervisor/conf.d/admix-worker.conf
 ${web_user} ALL=(ALL) NOPASSWD: /usr/bin/cp /tmp/admix_tune_* /etc/supervisor/conf.d/admix-worker.ini
@@ -291,8 +309,19 @@ ${web_user} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart php8.1-fpm
 ${web_user} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart php-fpm
 ${web_user} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart php8-fpm
 EOF
+
+  # Always ensure the PHP-FPM pool user (commonly www-data) can run certbot/nginx,
+  # even when it differs from the artisan file owner. This is the user that PHP web
+  # requests actually run as and the one that invokes sudo certbot from the app.
+  if [[ "${fpm_user}" != "${web_user}" ]] && id "${fpm_user}" >/dev/null 2>&1; then
+    cat >>/etc/sudoers.d/admixcentral <<EOF
+# SSL / Nginx (${fpm_user} — PHP-FPM pool runtime user)
+${fpm_user} ALL=(ALL) NOPASSWD: /usr/bin/certbot, ${certbot_bin}, /usr/sbin/nginx, /usr/bin/systemctl reload nginx, /usr/bin/tee /etc/nginx/sites-available/admixcentral, /usr/bin/tee /etc/nginx/conf.d/admixcentral.conf
+EOF
+  fi
+
   chmod 0440 /etc/sudoers.d/admixcentral || true
-  info "Sudoers written for user: ${web_user}"
+  info "Sudoers written for artisan owner: ${web_user}, PHP-FPM pool user: ${fpm_user}"
 
   # ── Phase 1: Frontend asset rebuild ─────────────────────────────────────────
   log "Phase 1 — Rebuilding frontend assets (echo.js timeout fix)"
@@ -312,6 +341,15 @@ EOF
       npm run build
     " && info "Frontend assets rebuilt" \
       || info "Warning: npm build failed — rebuild manually: npm run build"
+
+    # Re-apply group ownership and write permissions so administrator and www-data
+    # can both access these dirs without sudo after every build.
+    chown -R "${web_user}:www-data" "${INSTALL_DIR}/public/build"    2>/dev/null || true
+    chown -R "${web_user}:www-data" "${INSTALL_DIR}/node_modules"    2>/dev/null || true
+    find "${INSTALL_DIR}/public/build" -type d -exec chmod g+ws {} \; 2>/dev/null || true
+    find "${INSTALL_DIR}/public/build" -type f -exec chmod g+w  {} \; 2>/dev/null || true
+    find "${INSTALL_DIR}/node_modules" -type d -exec chmod g+ws {} \; 2>/dev/null || true
+    info "Permissions fixed: public/build + node_modules (group: www-data, group-writable)"
   else
     info "No package.json found — skipping frontend asset rebuild"
   fi


### PR DESCRIPTION
Add Cloudflare DNS-based certificate verification as an alternative to HTTP-01 (port 80) for Let's Encrypt SSL issuance and renewal.

## What's new
- SSL modal now has a verification method selector: HTTP or Cloudflare DNS
- Cloudflare API Token field (write-only, encrypted at rest via Laravel encrypt())
- Zone ID field with format validation (32-char hex)
- 'Reconfigure' button in the active SSL banner for changing method post-install
- Amber warning shown when switching method while a cert is already active
- GET /system/ssl/status endpoint hydrates the modal without exposing the token
- certbot-dns-cloudflare plugin check uses python3 import (no sudo required)
- --deploy-hook removed from DNS-01 path to avoid nested sudo prompt

## Fixes
- upgrade_admixcentral.sh was overwriting /etc/sudoers.d/admixcentral on every run using only the artisan file owner, silently dropping www-data entries and breaking certbot/nginx sudo for the PHP-FPM pool user
- Upgrade and install scripts now detect the actual PHP-FPM runtime user and always write a separate www-data SSL/Nginx sudoers block
- Certbot binary path resolved at runtime (handles /snap/bin/certbot)
- public/build and node_modules group ownership + write permissions re-applied after every npm build so 'npm run build' never requires sudo

## Deployment note (existing installations)
Run the upgrade script to apply all prerequisites automatically:

    sudo bash upgrade_admixcentral.sh

This will install python3-certbot-dns-cloudflare, fix /etc/sudoers.d/admixcentral for www-data, and restore group-write permissions on public/build.