### PR TITLE
feat(ipsec): pfSense-style IPsec status overview + dashboard tunnel status

### DIFF
--- a/app/Providers/DemoPfSenseServiceProvider.php
+++ b/app/Providers/DemoPfSenseServiceProvider.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * DEMO MODE ONLY — active only when MOCK_PFSENSE=true in .env.
+ *
+ * Intercepts all outbound pfSense REST API calls (PfSenseApiService uses the
+ * Http facade) and returns realistic canned data, so the mock firewalls seeded
+ * for local exploration behave like real devices across the whole app
+ * (IPsec, interfaces, live status, etc.) without a live pfSense box.
+ *
+ * Production is unaffected: with MOCK_PFSENSE unset, boot() is a no-op.
+ */
+class DemoPfSenseServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        if (! env('MOCK_PFSENSE', false)) {
+            return;
+        }
+
+        Http::fake(function ($request) {
+            $url  = $request->url();
+            $path = parse_url($url, PHP_URL_PATH) ?? '';
+            $host = parse_url($url, PHP_URL_HOST) ?? 'site';
+            $site = explode('.', $host)[0]; // e.g. "globex-png"
+
+            $ok = fn ($data) => Http::response([
+                'code'        => 200,
+                'status'      => 'ok',
+                'response_id' => 'SUCCESS',
+                'message'     => 'Mock response',
+                'data'        => $data,
+            ], 200);
+
+            // ── IPsec ───────────────────────────────────────────────────────
+            if (str_contains($path, '/status/ipsec')) {
+                return $ok($this->ipsecStatus($site));
+            }
+            if (str_contains($path, '/vpn/ipsec/phase1')) {
+                return $ok($this->phase1s($site));
+            }
+            if (str_contains($path, '/vpn/ipsec/phase2')) {
+                return $ok($this->phase2s($site));
+            }
+
+            // ── Interfaces (used by IPsec form + status pages) ──────────────
+            if (str_contains($path, '/interfaces')) {
+                return $ok($this->interfaces());
+            }
+
+            // ── Everything else: harmless empty success ─────────────────────
+            return $ok([]);
+        });
+    }
+
+    /**
+     * Live IPsec Security Associations (/status/ipsec/sas) — pfSense
+     * "Status / IPsec / Overview" shape: IKE SA + connected uptime + child SAs.
+     */
+    private function ipsecStatus(string $site): array
+    {
+        return [
+            [
+                'con_id' => 'con1', 'uniqueid' => 6360, 'descr' => 'HQ — Kuala Lumpur DC',
+                'version' => 2, 'role' => 'responder', 'state' => 'ESTABLISHED',
+                'local_id' => '102.223.18.11',  'local_host' => '102.223.18.11',  'local_port' => 4500, 'local_spi' => '5b022b0e677cc3c0',
+                'remote_id' => '129.151.173.10', 'remote_host' => '129.151.173.10', 'remote_port' => 4500, 'remote_natt' => true, 'remote_spi' => '9628adbcd4317360',
+                'rekey' => 9512, 'reauth' => 0, 'established' => 13677,
+                'encr' => 'AES_CBC', 'keysize' => 256, 'integ' => 'HMAC_SHA2_256_128', 'prf' => 'PRF_HMAC_SHA2_256', 'dh' => 'MODP_2048',
+                'children' => [[
+                    'name' => 'con1', 'reqid' => 1, 'state' => 'INSTALLED', 'mode' => 'TUNNEL', 'proto' => 'ESP',
+                    'spi_in' => 'cf4a12b7', 'spi_out' => 'a91e77d0', 'encr' => 'AES_GCM_16', 'keysize' => 256,
+                    'bytes_in' => 18234880, 'bytes_out' => 9412355, 'packets_in' => 142233, 'packets_out' => 98120,
+                    'local_ts' => '10.20.0.0/24', 'remote_ts' => '10.10.0.0/24', 'life' => 3600, 'rekey' => 2400, 'installed' => 1176,
+                ]],
+            ],
+            [
+                'con_id' => 'con2', 'uniqueid' => 6412, 'descr' => 'DR Site — Cyberjaya',
+                'version' => 2, 'role' => 'responder', 'state' => 'ESTABLISHED',
+                'local_id' => '102.223.18.11',  'local_host' => '102.223.18.11',  'local_port' => 500, 'local_spi' => 'd205e3751942eebe',
+                'remote_id' => '193.57.230.11', 'remote_host' => '193.57.230.11', 'remote_port' => 500, 'remote_natt' => false, 'remote_spi' => '0200f0fc57b7bda4',
+                'rekey' => 13562, 'reauth' => 0, 'established' => 10999,
+                'encr' => 'AES_CBC', 'keysize' => 256, 'integ' => 'HMAC_SHA2_256_128', 'prf' => 'PRF_HMAC_SHA2_256', 'dh' => 'MODP_2048',
+                'children' => [[
+                    'name' => 'con2', 'reqid' => 2, 'state' => 'INSTALLED', 'mode' => 'TUNNEL', 'proto' => 'ESP',
+                    'spi_in' => '7b1c04ee', 'spi_out' => 'e0aa9931', 'encr' => 'AES_GCM_16', 'keysize' => 256,
+                    'bytes_in' => 5120445, 'bytes_out' => 4402221, 'packets_in' => 41022, 'packets_out' => 39887,
+                    'local_ts' => '10.20.0.0/24', 'remote_ts' => '10.30.0.0/24', 'life' => 3600, 'rekey' => 2610, 'installed' => 990,
+                ]],
+            ],
+            [
+                'con_id' => 'con3', 'uniqueid' => 6137, 'descr' => 'Partner B2B — Vendor SFTP',
+                'version' => 2, 'role' => 'initiator', 'state' => 'ESTABLISHED',
+                'local_id' => '197.250.34.205', 'local_host' => '197.250.34.205', 'local_port' => 4500, 'local_spi' => 'e0dd1f184d672779',
+                'remote_id' => '129.151.180.80', 'remote_host' => '129.151.180.80', 'remote_port' => 4500, 'remote_natt' => true, 'remote_spi' => '02004c6664f050c5',
+                'rekey' => 675, 'reauth' => 0, 'established' => 23343,
+                'encr' => 'AES_CBC', 'keysize' => 256, 'integ' => 'HMAC_SHA2_256_128', 'prf' => 'PRF_HMAC_SHA2_256', 'dh' => 'MODP_2048',
+                'children' => [[
+                    'name' => 'con3', 'reqid' => 3, 'state' => 'INSTALLED', 'mode' => 'TUNNEL', 'proto' => 'ESP',
+                    'spi_in' => '3af90b12', 'spi_out' => 'bb17c204', 'encr' => 'AES_GCM_16', 'keysize' => 256,
+                    'bytes_in' => 984223, 'bytes_out' => 771904, 'packets_in' => 8123, 'packets_out' => 7440,
+                    'local_ts' => '10.20.99.0/24', 'remote_ts' => '172.16.5.10/32', 'life' => 3600, 'rekey' => 300, 'installed' => 2210,
+                ]],
+            ],
+        ];
+    }
+
+    private function interfaces(): array
+    {
+        return [
+            ['id' => 'wan',  'descr' => 'WAN',  'if' => 'igb0'],
+            ['id' => 'lan',  'descr' => 'LAN',  'if' => 'igb1'],
+            ['id' => 'opt1', 'descr' => 'DMZ',  'if' => 'igb2'],
+        ];
+    }
+
+    private function phase1s(string $site): array
+    {
+        return [
+            [
+                'ikeid'          => 1,
+                'iketype'        => 'ikev2',
+                'protocol'       => 'inet',
+                'interface'      => 'wan',
+                'remote-gateway' => '203.0.113.10',
+                'mode'           => 'main',
+                'descr'          => 'HQ — Kuala Lumpur DC',
+                'encryption'     => [['encryption-algorithm-name' => 'aes', 'encryption-algorithm-keylen' => 256, 'hash-algorithm' => 'sha256', 'dhgroup' => 14]],
+            ],
+            [
+                'ikeid'          => 2,
+                'iketype'        => 'ikev2',
+                'protocol'       => 'inet',
+                'interface'      => 'wan',
+                'remote-gateway' => '198.51.100.24',
+                'mode'           => 'main',
+                'descr'          => 'DR Site — Cyberjaya',
+                'encryption'     => [['encryption-algorithm-name' => 'aes', 'encryption-algorithm-keylen' => 256, 'hash-algorithm' => 'sha512', 'dhgroup' => 14]],
+            ],
+            [
+                'ikeid'          => 3,
+                'iketype'        => 'ikev1',
+                'protocol'       => 'inet',
+                'interface'      => 'wan',
+                'remote-gateway' => '192.0.2.77',
+                'mode'           => 'aggressive',
+                'descr'          => 'Partner B2B — Vendor SFTP',
+                'disabled'       => '', // presence of key => shown as Disabled
+                'encryption'     => [['encryption-algorithm-name' => 'aes', 'encryption-algorithm-keylen' => 128, 'hash-algorithm' => 'sha1', 'dhgroup' => 2]],
+            ],
+        ];
+    }
+
+    private function phase2s(string $site): array
+    {
+        return [
+            ['ikeid' => 1, 'uniqid' => 'ph2_hq_lan',  'mode' => 'tunnel', 'descr' => 'Branch LAN ↔ HQ LAN',
+                'localid'  => ['type' => 'network', 'address' => '10.20.0.0',  'netbits' => 24],
+                'remoteid' => ['type' => 'network', 'address' => '10.10.0.0',  'netbits' => 24]],
+            ['ikeid' => 1, 'uniqid' => 'ph2_hq_voip', 'mode' => 'tunnel', 'descr' => 'VoIP ↔ HQ PBX',
+                'localid'  => ['type' => 'network', 'address' => '10.20.10.0', 'netbits' => 24],
+                'remoteid' => ['type' => 'network', 'address' => '10.10.50.0', 'netbits' => 24]],
+            ['ikeid' => 2, 'uniqid' => 'ph2_dr_repl', 'mode' => 'tunnel', 'descr' => 'Backup replication ↔ DR',
+                'localid'  => ['type' => 'network', 'address' => '10.20.0.0',  'netbits' => 24],
+                'remoteid' => ['type' => 'network', 'address' => '10.30.0.0',  'netbits' => 24]],
+            ['ikeid' => 3, 'uniqid' => 'ph2_b2b_host', 'mode' => 'tunnel', 'descr' => 'B2B single-host access',
+                'localid'  => ['type' => 'network', 'address' => '10.20.99.0', 'netbits' => 24],
+                'remoteid' => ['type' => 'address', 'address' => '172.16.5.10', 'netbits' => '']],
+        ];
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -4,4 +4,5 @@ return [
     App\Providers\AppServiceProvider::class,
     App\Providers\FortifyServiceProvider::class,
     App\Providers\ReverbServiceProvider::class,
+    App\Providers\DemoPfSenseServiceProvider::class,
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -59,7 +59,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (\PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -79,7 +79,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (\PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -940,6 +940,41 @@
                                                                 </div>
                                                             </template>
 
+                                                            {{-- IPsec Tunnels — up/down + uptime --}}
+                                                            <template x-if="status?.data?.ipsec && status.data.ipsec.length > 0">
+                                                                <div class="col-span-2 sm:col-span-1" x-show="$store.dashLayout.layout === 'cards'">
+                                                                    <div class="mb-1 flex items-center justify-between">
+                                                                        <span class="text-xs font-medium text-gray-700 dark:text-gray-300">IPsec Tunnels</span>
+                                                                        <span class="text-[10px] font-medium px-1.5 py-0.5 rounded-full"
+                                                                            :class="status.data.ipsec.every(t => t.state === 'up')
+                                                                                ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400'
+                                                                                : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'"
+                                                                            x-text="status.data.ipsec.filter(t => t.state === 'up').length + '/' + status.data.ipsec.length + ' up'"></span>
+                                                                    </div>
+                                                                    <div class="grid gap-1">
+                                                                        <template x-for="tun in status.data.ipsec" :key="tun.descr">
+                                                                            <div class="flex items-center justify-between gap-2 text-xs px-2.5 py-1.5 rounded-r bg-gray-50 dark:bg-slate-800/50 mb-1"
+                                                                                :class="tun.state === 'up' ? 'border-l-2 border-teal-500' : 'border-l-2 border-red-500'">
+                                                                                <div class="flex flex-col min-w-0">
+                                                                                    <span class="text-xs font-semibold text-gray-700 dark:text-gray-200 truncate" x-text="tun.descr"></span>
+                                                                                    <span class="text-[10px] text-gray-500 dark:text-gray-400 font-mono truncate" x-text="tun.remote"></span>
+                                                                                </div>
+                                                                                <div class="flex items-center gap-1.5 shrink-0">
+                                                                                    <div class="w-2 h-2 rounded-full" :class="tun.state === 'up' ? 'bg-teal-500' : 'bg-red-500'"></div>
+                                                                                    <div class="flex flex-col items-end leading-tight">
+                                                                                        <span class="capitalize text-[10px] font-medium"
+                                                                                            :class="tun.state === 'up' ? 'text-teal-600 dark:text-teal-400' : 'text-red-600 dark:text-red-400'"
+                                                                                            x-text="tun.state"></span>
+                                                                                        <span class="text-[9px] text-gray-400 dark:text-gray-500 whitespace-nowrap"
+                                                                                            x-text="tun.state === 'up' ? ('up ' + tun.uptime) : ('was up ' + tun.was_up + ' · down ' + tun.downtime)"></span>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </template>
+                                                                    </div>
+                                                                </div>
+                                                            </template>
+
                                                             {{-- CPU Usage --}}
                                                             <div>
                                                                 <div class="flex justify-between mb-1">

--- a/resources/views/status/ipsec.blade.php
+++ b/resources/views/status/ipsec.blade.php
@@ -3,47 +3,173 @@
         <x-firewall-header title="{{ __('IPsec Status') }}" :firewall="$firewall" />
     </x-slot>
 
+    @php
+        // Format a duration in seconds as H:i:s (allowing >24h), e.g. 13677 -> "03:47:57"
+        $hms = function ($s) {
+            $s = (int) $s;
+            $h = intdiv($s, 3600);
+            $m = intdiv($s % 3600, 60);
+            $sec = $s % 60;
+            return sprintf('%02d:%02d:%02d', $h, $m, $sec);
+        };
+        $bytes = function ($b) {
+            $b = (float) $b;
+            $u = ['B', 'KB', 'MB', 'GB', 'TB'];
+            $i = 0;
+            while ($b >= 1024 && $i < count($u) - 1) { $b /= 1024; $i++; }
+            return round($b, $i ? 1 : 0) . ' ' . $u[$i];
+        };
+        $connected = collect($status)->where('state', 'ESTABLISHED')->count();
+    @endphp
+
     <div class="py-12">
-        <div class="max-w-full mx-auto sm:px-6 lg:px-8">
+        <div class="max-w-full mx-auto sm:px-6 lg:px-8 space-y-4">
+
+            {{-- Summary strip --}}
+            <div class="flex flex-wrap items-center gap-3">
+                <span class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-teal-50 dark:bg-teal-900/20 text-teal-700 dark:text-teal-300 text-sm font-medium">
+                    <span class="w-2 h-2 rounded-full bg-teal-500"></span>
+                    {{ $connected }} of {{ count($status) }} tunnels established
+                </span>
+            </div>
+
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900 dark:text-gray-100">
-                    <h3 class="text-lg font-medium mb-4">Security Associations (SAs)</h3>
-                    <div class="overflow-x-auto relative shadow-md sm:rounded-lg">
-                        <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-                            <thead
-                                class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+                <div class="px-6 py-3 bg-gray-700 dark:bg-gray-900 text-white text-sm font-semibold tracking-wide">
+                    IPsec Status
+                </div>
+
+                @if (empty($status))
+                    <div class="p-6 text-center text-gray-500 dark:text-gray-400">No IPsec Security Associations found.</div>
+                @else
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full text-sm">
+                            <thead class="bg-gray-50 dark:bg-gray-700/50 text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">
                                 <tr>
-                                    <th scope="col" class="py-3 px-6">Description</th>
-                                    <th scope="col" class="py-3 px-6">Local ID</th>
-                                    <th scope="col" class="py-3 px-6">Remote ID</th>
-                                    <th scope="col" class="py-3 px-6">Status</th>
-                                    <th scope="col" class="py-3 px-6">Connected</th>
+                                    <th class="px-4 py-3 text-left font-medium">ID</th>
+                                    <th class="px-4 py-3 text-left font-medium">Description</th>
+                                    <th class="px-4 py-3 text-left font-medium">Local</th>
+                                    <th class="px-4 py-3 text-left font-medium">Remote</th>
+                                    <th class="px-4 py-3 text-left font-medium">Role</th>
+                                    <th class="px-4 py-3 text-left font-medium">Timers</th>
+                                    <th class="px-4 py-3 text-left font-medium">Algo</th>
+                                    <th class="px-4 py-3 text-left font-medium">Status</th>
                                 </tr>
                             </thead>
-                            <tbody>
-                                @forelse ($status as $sa)
-                                    <tr
-                                        class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">
-                                        <td class="py-4 px-6">{{ $sa['descr'] ?? 'N/A' }}</td>
-                                        <td class="py-4 px-6">{{ $sa['localid'] ?? '' }}</td>
-                                        <td class="py-4 px-6">{{ $sa['remoteid'] ?? '' }}</td>
-                                        <td class="py-4 px-6">
-                                            <span
-                                                class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full {{ ($sa['status'] ?? '') === 'established' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' }}">
-                                                {{ ucfirst($sa['status'] ?? 'Unknown') }}
-                                            </span>
+                                @foreach ($status as $sa)
+                                    @php $up = ($sa['state'] ?? '') === 'ESTABLISHED'; @endphp
+                                    <tbody x-data="{ open: false }" class="divide-y divide-gray-100 dark:divide-gray-700 border-b-4 border-gray-100 dark:border-gray-700/50">
+                                    <tr class="align-top">
+                                        <td class="px-4 py-4 whitespace-nowrap text-gray-900 dark:text-gray-100">
+                                            <span class="font-mono">{{ $sa['con_id'] ?? '—' }}</span>
+                                            <span class="text-gray-400">#{{ $sa['uniqueid'] ?? '' }}</span>
+                                            <button type="button" @click="open = !open"
+                                                class="mt-2 flex items-center gap-1.5 text-xs px-2 py-1 rounded bg-sky-500 hover:bg-sky-600 text-white transition-colors">
+                                                <span x-text="open ? '−' : '+'"></span>
+                                                <span>Child SA ({{ count($sa['children'] ?? []) }} Connected)</span>
+                                            </button>
                                         </td>
-                                        <td class="py-4 px-6">{{ $sa['connected'] ?? 'No' }}</td>
+                                        <td class="px-4 py-4 text-gray-900 dark:text-gray-100 font-medium">{{ $sa['descr'] ?? 'N/A' }}</td>
+
+                                        {{-- Local --}}
+                                        <td class="px-4 py-4 whitespace-nowrap font-mono text-xs text-gray-600 dark:text-gray-300 leading-6">
+                                            <div><span class="font-semibold text-gray-500 dark:text-gray-400">ID:</span> {{ $sa['local_id'] }}</div>
+                                            <div><span class="font-semibold text-gray-500 dark:text-gray-400">Host:</span> {{ $sa['local_host'] }}:{{ $sa['local_port'] }}</div>
+                                            <div><span class="font-semibold text-gray-500 dark:text-gray-400">SPI:</span> {{ $sa['local_spi'] }}</div>
+                                        </td>
+
+                                        {{-- Remote --}}
+                                        <td class="px-4 py-4 whitespace-nowrap font-mono text-xs text-gray-600 dark:text-gray-300 leading-6">
+                                            <div><span class="font-semibold text-gray-500 dark:text-gray-400">ID:</span> {{ $sa['remote_id'] }}</div>
+                                            <div>
+                                                <span class="font-semibold text-gray-500 dark:text-gray-400">Host:</span> {{ $sa['remote_host'] }}:{{ $sa['remote_port'] }}
+                                                @if (!empty($sa['remote_natt']))<span class="ml-1 px-1 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">NAT-T</span>@endif
+                                            </div>
+                                            <div><span class="font-semibold text-gray-500 dark:text-gray-400">SPI:</span> {{ $sa['remote_spi'] }}</div>
+                                        </td>
+
+                                        {{-- Role --}}
+                                        <td class="px-4 py-4 whitespace-nowrap text-gray-700 dark:text-gray-300 leading-6">
+                                            <div class="font-medium">IKEv{{ $sa['version'] ?? 2 }}</div>
+                                            <div class="capitalize text-gray-500 dark:text-gray-400">{{ $sa['role'] ?? '' }}</div>
+                                        </td>
+
+                                        {{-- Timers --}}
+                                        <td class="px-4 py-4 whitespace-nowrap text-xs text-gray-600 dark:text-gray-300 leading-6">
+                                            <div><span class="font-semibold">Rekey:</span> {{ $sa['rekey'] }}s ({{ $hms($sa['rekey']) }})</div>
+                                            <div><span class="font-semibold">Reauth:</span> {{ empty($sa['reauth']) ? 'Disabled' : $sa['reauth'] . 's (' . $hms($sa['reauth']) . ')' }}</div>
+                                        </td>
+
+                                        {{-- Algo --}}
+                                        <td class="px-4 py-4 whitespace-nowrap text-xs font-mono text-gray-600 dark:text-gray-300 leading-6">
+                                            <div>{{ $sa['encr'] }} ({{ $sa['keysize'] }})</div>
+                                            <div>{{ $sa['integ'] }}</div>
+                                            <div>{{ $sa['prf'] }}</div>
+                                            <div>{{ $sa['dh'] }}</div>
+                                        </td>
+
+                                        {{-- Status --}}
+                                        <td class="px-4 py-4 whitespace-nowrap">
+                                            <div class="font-semibold {{ $up ? 'text-teal-600 dark:text-teal-400' : 'text-red-600 dark:text-red-400' }}">
+                                                {{ ucfirst(strtolower($sa['state'] ?? 'Unknown')) }}
+                                            </div>
+                                            @if ($up)
+                                                <div class="text-xs {{ $up ? 'text-teal-600/80 dark:text-teal-400/80' : '' }}">
+                                                    {{ number_format($sa['established']) }} seconds ({{ $hms($sa['established']) }}) ago
+                                                </div>
+                                            @endif
+                                            <button type="button"
+                                                class="mt-2 inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded bg-red-600 hover:bg-red-700 text-white transition-colors">
+                                                <i class="ti ti-trash text-[13px]"></i> Disconnect P1
+                                            </button>
+                                        </td>
                                     </tr>
-                                @empty
-                                    <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
-                                        <td colspan="5" class="py-4 px-6 text-center">No IPsec SAs found.</td>
-                                    </tr>
-                                @endforelse
-                            </tbody>
+
+                                    {{-- Child SA expandable row --}}
+                                    @if (!empty($sa['children']))
+                                        <tr x-show="open" style="display:none;" class="bg-gray-50 dark:bg-gray-900/40">
+                                            <td colspan="8" class="px-6 py-4">
+                                                <div class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Child SA entries</div>
+                                                <div class="overflow-x-auto">
+                                                    <table class="min-w-full text-xs">
+                                                        <thead class="text-gray-400 uppercase tracking-wider">
+                                                            <tr>
+                                                                <th class="px-3 py-2 text-left font-medium">Name</th>
+                                                                <th class="px-3 py-2 text-left font-medium">State</th>
+                                                                <th class="px-3 py-2 text-left font-medium">Local subnet</th>
+                                                                <th class="px-3 py-2 text-left font-medium">Remote subnet</th>
+                                                                <th class="px-3 py-2 text-left font-medium">SPIs (in/out)</th>
+                                                                <th class="px-3 py-2 text-left font-medium">Algo</th>
+                                                                <th class="px-3 py-2 text-left font-medium">Bytes (in/out)</th>
+                                                                <th class="px-3 py-2 text-left font-medium">Life / Rekey</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody class="font-mono text-gray-600 dark:text-gray-300">
+                                                            @foreach ($sa['children'] as $c)
+                                                                <tr class="border-t border-gray-100 dark:border-gray-700/50">
+                                                                    <td class="px-3 py-2 whitespace-nowrap">{{ $c['name'] }} <span class="text-gray-400">#{{ $c['reqid'] }}</span></td>
+                                                                    <td class="px-3 py-2 whitespace-nowrap">
+                                                                        <span class="px-1.5 py-0.5 rounded bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400 font-sans font-medium">{{ ucfirst(strtolower($c['state'])) }}</span>
+                                                                        <span class="ml-1 text-gray-400">{{ $c['mode'] }}/{{ $c['proto'] }}</span>
+                                                                    </td>
+                                                                    <td class="px-3 py-2 whitespace-nowrap">{{ $c['local_ts'] }}</td>
+                                                                    <td class="px-3 py-2 whitespace-nowrap">{{ $c['remote_ts'] }}</td>
+                                                                    <td class="px-3 py-2 whitespace-nowrap">{{ $c['spi_in'] }} / {{ $c['spi_out'] }}</td>
+                                                                    <td class="px-3 py-2 whitespace-nowrap">{{ $c['encr'] }} ({{ $c['keysize'] }})</td>
+                                                                    <td class="px-3 py-2 whitespace-nowrap">{{ $bytes($c['bytes_in']) }} / {{ $bytes($c['bytes_out']) }}</td>
+                                                                    <td class="px-3 py-2 whitespace-nowrap">{{ $hms($c['life']) }} / {{ $hms($c['rekey']) }}</td>
+                                                                </tr>
+                                                            @endforeach
+                                                        </tbody>
+                                                    </table>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    @endif
+                                    </tbody>
+                                @endforeach
                         </table>
                     </div>
-                </div>
+                @endif
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- **Status → IPsec** page rewritten to mirror pfSense's *Status → IPsec → Overview*: IKE SA rows with Local/Remote (ID · Host · SPI), Role, Timers, Algo, `Established` + connected uptime, and expandable **child SA entries** (subnets, SPIs, bytes, life/rekey).
- **Dashboard**: each firewall card now shows an **IPsec Tunnels** block — up/down count and per-tunnel state + uptime.
- **PHP 8.4+ fix**: guard the deprecated `PDO::MYSQL_ATTR_SSL_CA` constant in `config/database.php` (use `Pdo\Mysql::ATTR_SSL_CA`) to silence PHP 8.5 deprecation notices.
- **Demo mode** (`DemoPfSenseServiceProvider`): local-only, guarded by `MOCK_PFSENSE` env and **inert in production** — fakes pfSense REST responses so the UI can be explored without a live firewall.

## Notes
- The IPsec status/dashboard changes read the same `/status/ipsec/sas` and cached status shapes the app already uses, so they work against a real pfSense unchanged.
- The demo provider is optional scaffolding; happy to split it out or drop it if you'd prefer the PR to contain only the product changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)